### PR TITLE
Set `kind` for features other than towns in California

### DIFF
--- a/US/US-CA.csv
+++ b/US/US-CA.csv
@@ -1,2 +1,5 @@
 token,text,easting,southing,kind,signed,access,industry,city,country,show,checked,remark,ref
-ca_ggbridge,Golden Gate Bridge,,,,,,,,US-CA,yes,,,
+ca_crestw,Crestwood Summit,,,pass,,,,,US-CA,yes,,,
+ca_ggbridge,Golden Gate Bridge,,,bridge,,,,,US-CA,yes,,,
+ca_lassenpk,Lassen Park,,,nature,remote,no,,,US-CA,no,2024,,
+ca_tiogapass,Tioga Pass,,,pass,,,,,US-CA,yes,,,

--- a/label-metadata.md
+++ b/label-metadata.md
@@ -333,7 +333,8 @@ May be used in future to prioritize dataset maintenance. High precision isn't
 necessary; the date formats `YYYY` or `YYYY-MM` should be adequate.
 
 Checking / assessing usually requires looking at the in-game location using
-the dev cam.
+the dev cam. If the installed game version isn't current, the year of that
+version's release should be used here.
 
 ### remark
 


### PR DESCRIPTION
Addresses https://github.com/truckermudgeon/maps/pull/72#discussion_r2347023829.

The metadata description [suggests](https://github.com/nautofon/ats-towns/blob/80e9195402d8e3adb9ee8528488203a3b16e8710/label-metadata.md#kind) to use `hamlet` instead of `town` for really tiny towns. While I do feel `hamlet` is a useful concept and want to introduce it to the dataset at some point, this particular change doesn't do so. There are several candidates for `hamlet` in California though, for example [California Valley](https://truckermudgeon.github.io/#8.78/35.0663/-119.9382).